### PR TITLE
Update Matrix Dimensions Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ A parametric OpenSCAD generator for 3D-printable NeoPixel diffuser attachments.
 
 ## Target Configurations
 
-### 16x16 Matrix (160x160mm)
-- **Dimensions:** 160x160mm
+### 16x16 Matrix (160x160mm / 6.3x6.3")
+- **Dimensions:** 160x160mm (6.3 x 6.3 inches)
 - **LED Pitch:** 10mm
 - **Layout:** 16 rows, 16 columns
 
 ![16x16 Diffuser](images/diffuser_16x16.png)
 
-### 8x32 Matrix (80x320mm)
-- **Dimensions:** 80x320mm
+### 8x32 Matrix (80x320mm / 3.15x12.6")
+- **Dimensions:** 80x320mm (3.15 x 12.6 inches)
 - **LED Pitch:** 10mm
 - **Layout:** 8 rows, 32 columns
 


### PR DESCRIPTION
This PR updates the project documentation to include imperial unit conversions for the target NeoPixel matrix configurations.

- Added (6.3 x 6.3 inches) for the 16x16 matrix.
- Added (3.15 x 12.6 inches) for the 8x32 matrix.

No changes were made to the core OpenSCAD logic or configuration parameters, as the existing 10mm pitch already correctly produces the requested 160x160mm dimensions for a 16x16 grid.

Fixes #22

---
*PR created automatically by Jules for task [12721770156910499741](https://jules.google.com/task/12721770156910499741) started by @chatelao*