### PR TITLE
Add GitHub Pages link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A parametric OpenSCAD generator for 3D-printable NeoPixel diffuser attachments.
 
+## Live Preview
+Explore the generated 3D models directly in your browser:
+[https://chatelao.github.io/neopixel-diffusor-3d-print/](https://chatelao.github.io/neopixel-diffusor-3d-print/)
+
 ## Target Configurations
 
 ### 16x16 Matrix (160x160mm / 6.3x6.3")


### PR DESCRIPTION
This PR adds a link to the GitHub Pages site in the README.md file. This provides users with easy access to the interactive 3D viewer for the generated STL files.

Fixes #31

---
*PR created automatically by Jules for task [5962754098988542773](https://jules.google.com/task/5962754098988542773) started by @chatelao*