### PR TITLE
Fix failed GitHub build by removing unsupported --multi flag

### DIFF
--- a/.github/workflows/generate_stls.yml
+++ b/.github/workflows/generate_stls.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Generate STLs and Renderings
       run: |
         mkdir -p stl images
-        python3 scripts/generate_stl.py --multi
+        python3 scripts/generate_stl.py
 
     - name: Sync STLs to docs
       run: |


### PR DESCRIPTION
This PR fixes a failing GitHub Action build by removing an unsupported `--multi` argument from the `python3 scripts/generate_stl.py` command in the workflow. The script now handles multi-version generation by default, making the flag obsolete and causing an argument parsing error.

Fixes #43

---
*PR created automatically by Jules for task [13974440194076222064](https://jules.google.com/task/13974440194076222064) started by @chatelao*